### PR TITLE
Add profile modal and polish login

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -199,10 +199,24 @@ body.light-mode {
 .checkmark { font-size:3.2rem; color: var(--success); margin-bottom:.5rem; }
 
 /* Auth */
-.auth-card { max-width:420px; margin:4rem auto; background:var(--card-bg); padding:2rem; border-radius:16px; border:1px solid rgba(127,23,52,.3); }
+.auth-page .main { min-height:100vh; display:flex; justify-content:center; align-items:center; margin-top:0; padding:0; }
+.auth-card { max-width:420px; width:100%; margin:0; background:var(--card-bg); padding:2rem; border-radius:16px; border:1px solid rgba(127,23,52,.3); position:relative; box-shadow:0 16px 40px rgba(0,0,0,.35); }
+.auth-card::before { content:""; position:absolute; inset:0 0 auto 0; height:4px; background:linear-gradient(90deg,var(--claret),var(--blue)); border-top-left-radius:16px; border-top-right-radius:16px; }
+.auth-card h2 { text-align:center; margin-bottom:1.2rem; background:linear-gradient(90deg,var(--claret),var(--blue)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
 .login-form { display:flex; flex-direction:column; gap:1rem; }
-.login-form input { padding:.8rem 1rem; border-radius:8px; border:1px solid rgba(127,23,52,.3); background:var(--darker-bg); color:var(--text-light); }
+.input-group { display:flex; align-items:center; border:1px solid rgba(127,23,52,.3); border-radius:8px; background:var(--darker-bg); }
+.input-icon { padding:0 .8rem; color:var(--text-muted); }
+.input-group input { flex:1; padding:.8rem 1rem; background:transparent; border:0; color:var(--text-light); }
+.input-group input:focus { outline:none; }
 .login-form button { width:100%; }
+
+/* Profile */
+.profile-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(140px,1fr)); gap:1rem; margin-bottom:1rem; }
+.profile-card { background:var(--darker-bg); border:1px solid rgba(127,23,52,.3); border-radius:12px; overflow:hidden; }
+.profile-card img { width:100%; height:90px; object-fit:cover; }
+.profile-card .info { padding:.5rem .6rem; }
+.profile-card h4 { font-size:.95rem; margin-bottom:.2rem; }
+.profile-card .tickets { color:var(--text-muted); font-size:.85rem; margin-top:.3rem; }
 
 /* Winners & FAQ placeholders */
 .winners-gallery { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1.2rem; }

--- a/css/styles.css
+++ b/css/styles.css
@@ -198,6 +198,12 @@ body.light-mode {
 .success-message { text-align:center; padding:2rem; }
 .checkmark { font-size:3.2rem; color: var(--success); margin-bottom:.5rem; }
 
+/* Auth */
+.auth-card { max-width:420px; margin:4rem auto; background:var(--card-bg); padding:2rem; border-radius:16px; border:1px solid rgba(127,23,52,.3); }
+.login-form { display:flex; flex-direction:column; gap:1rem; }
+.login-form input { padding:.8rem 1rem; border-radius:8px; border:1px solid rgba(127,23,52,.3); background:var(--darker-bg); color:var(--text-light); }
+.login-form button { width:100%; }
+
 /* Winners & FAQ placeholders */
 .winners-gallery { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1.2rem; }
 .winner-card { background: var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:14px; padding:1.2rem; }

--- a/index.html
+++ b/index.html
@@ -23,10 +23,8 @@
         <li><a href="#" class="nav-link" data-page="big-raffles">Big Raffles</a></li>
         <li><a href="#" class="nav-link" data-page="winners">Past Winners</a></li>
         <li><a href="#" class="nav-link" data-page="faq">FAQ</a></li>
-        <li id="accountNav" style="display:none;"><a href="#" class="nav-link" data-page="account">My Account</a></li>
-        <li>
-          <a id="loginLink" class="button button-outline" href="login.html">Login</a>
-        </li>
+        <li><button id="profileBtn" class="button button-outline" style="display:none;">Profile</button></li>
+        <li><a id="loginLink" class="button button-outline" href="login.html">Login</a></li>
       </ul>
       <button id="themeToggle" class="theme-toggle" aria-label="Toggle light mode">🌙</button>
       <div class="mobile-menu" id="mobileMenu">
@@ -121,22 +119,6 @@
 
       </section>
 
-      <section id="account" class="page">
-        <h2>My Account</h2>
-        <p>Balance: £<span id="userBalance">0.00</span></p>
-
-        <h3>Current Entries</h3>
-        <ul id="userCurrentEntries"></ul>
-
-        <h3>Past Raffles</h3>
-        <ul id="userPastRaffles"></ul>
-
-        <h3>Won Raffles</h3>
-        <ul id="userWonRaffles"></ul>
-
-        <h3>Stats</h3>
-        <p>Spent: £<span id="userSpent">0.00</span> | Won: £<span id="userWon">0.00</span></p>
-      </section>
     </div>
   </main>
 
@@ -181,6 +163,25 @@
         <h2>Entry Successful!</h2>
         <p>You're in the draw. Good luck! 🍀</p>
       </div>
+    </div>
+  </div>
+
+  <!-- Profile Modal -->
+  <div id="profileModal" class="modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>My Profile</h2>
+        <button class="close-modal" data-close>×</button>
+      </div>
+      <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <h3>Current Entries</h3>
+      <ul id="modalCurrentEntries"></ul>
+      <h3>Past Raffles</h3>
+      <ul id="modalPastRaffles"></ul>
+      <h3>Won Raffles</h3>
+      <ul id="modalWonRaffles"></ul>
+      <h3>Stats</h3>
+      <p>Spent: £<span id="modalSpent">0.00</span> | Won: £<span id="modalWon">0.00</span></p>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -175,11 +175,11 @@
       </div>
       <p>Balance: £<span id="modalBalance">0.00</span></p>
       <h3>Current Entries</h3>
-      <ul id="modalCurrentEntries"></ul>
+      <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>
-      <ul id="modalPastRaffles"></ul>
+      <div id="modalPastRaffles" class="profile-grid"></div>
       <h3>Won Raffles</h3>
-      <ul id="modalWonRaffles"></ul>
+      <div id="modalWonRaffles" class="profile-grid"></div>
       <h3>Stats</h3>
       <p>Spent: £<span id="modalSpent">0.00</span> | Won: £<span id="modalWon">0.00</span></p>
     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -253,8 +253,8 @@ function addUserTicketsFor(raffleId, n) {
 
 // demo past data for account page
 const demoPast = [
-  { title: 'PS5 Bundle', spent: 4, won: false },
-  { title: '£100 Gift Card', spent: 2, won: true, prize: 100 }
+  { title: 'PS5 Bundle', spent: 4, won: false, image: 'images/gamingsetup.png' },
+  { title: '£100 Gift Card', spent: 2, won: true, prize: 100, image: 'images/spaweekend.png' }
 ];
 
 function renderProfile() {
@@ -267,26 +267,30 @@ function renderProfile() {
   raffles.forEach(r => {
     const t = getUserTicketsFor(r.id);
     if (t > 0) {
-      const li = document.createElement('li');
-      li.textContent = `${r.title} — ${t} tickets`;
-      currentList.appendChild(li);
+      const card = document.createElement('div');
+      card.className = 'profile-card';
+      card.innerHTML = `<img src="${r.image}" alt="${r.title}"><div class="info"><h4>${r.title}</h4><div class="tickets">${t} ticket${t>1?'s':''}</div></div>`;
+      currentList.appendChild(card);
     }
   });
 
   const pastList = $('#modalPastRaffles');
   pastList.innerHTML = '';
   demoPast.forEach(r => {
-    const li = document.createElement('li');
-    li.textContent = `${r.title} — ${r.won ? `Won £${r.prize}` : 'Lost'} (spent £${r.spent})`;
-    pastList.appendChild(li);
+    const card = document.createElement('div');
+    card.className = 'profile-card';
+    const status = r.won ? `Won £${r.prize}` : 'Lost';
+    card.innerHTML = `<img src="${r.image}" alt="${r.title}"><div class="info"><h4>${r.title}</h4><div class="tickets">${status} (spent £${r.spent})</div></div>`;
+    pastList.appendChild(card);
   });
 
   const wonList = $('#modalWonRaffles');
   wonList.innerHTML = '';
   demoPast.filter(r => r.won).forEach(r => {
-    const li = document.createElement('li');
-    li.textContent = `${r.title} — £${r.prize}`;
-    wonList.appendChild(li);
+    const card = document.createElement('div');
+    card.className = 'profile-card';
+    card.innerHTML = `<img src="${r.image}" alt="${r.title}"><div class="info"><h4>${r.title}</h4><div class="tickets">£${r.prize}</div></div>`;
+    wonList.appendChild(card);
   });
 
   const spent = getSpent() + demoPast.reduce((s, r) => s + r.spent, 0);

--- a/js/script.js
+++ b/js/script.js
@@ -257,12 +257,12 @@ const demoPast = [
   { title: '£100 Gift Card', spent: 2, won: true, prize: 100 }
 ];
 
-function renderAccount() {
-  const balEl = $('#userBalance');
+function renderProfile() {
+  const balEl = $('#modalBalance');
   if (!balEl) return;
   balEl.textContent = getBalance().toFixed(2);
 
-  const currentList = $('#userCurrentEntries');
+  const currentList = $('#modalCurrentEntries');
   currentList.innerHTML = '';
   raffles.forEach(r => {
     const t = getUserTicketsFor(r.id);
@@ -273,7 +273,7 @@ function renderAccount() {
     }
   });
 
-  const pastList = $('#userPastRaffles');
+  const pastList = $('#modalPastRaffles');
   pastList.innerHTML = '';
   demoPast.forEach(r => {
     const li = document.createElement('li');
@@ -281,7 +281,7 @@ function renderAccount() {
     pastList.appendChild(li);
   });
 
-  const wonList = $('#userWonRaffles');
+  const wonList = $('#modalWonRaffles');
   wonList.innerHTML = '';
   demoPast.filter(r => r.won).forEach(r => {
     const li = document.createElement('li');
@@ -291,8 +291,8 @@ function renderAccount() {
 
   const spent = getSpent() + demoPast.reduce((s, r) => s + r.spent, 0);
   const wonAmt = demoPast.filter(r => r.won).reduce((s, r) => s + (r.prize || 0), 0);
-  $('#userSpent').textContent = spent.toFixed(2);
-  $('#userWon').textContent = wonAmt.toFixed(2);
+  $('#modalSpent').textContent = spent.toFixed(2);
+  $('#modalWon').textContent = wonAmt.toFixed(2);
 }
 
 function completeEntry() {
@@ -338,16 +338,16 @@ function completeEntry() {
   renderTop3();
   filterRaffles();
   renderBigRaffles();
-  renderAccount();
+  renderProfile();
 }
 
 /* ====== EVENTS ====== */
 document.addEventListener('DOMContentLoaded', () => {
   // Auth setup
   const loginLink = $('#loginLink');
-  const accountNav = $('#accountNav');
+  const profileBtn = $('#profileBtn');
   if (isLoggedIn()) {
-    accountNav.style.display = 'block';
+    profileBtn.style.display = 'inline-block';
     loginLink.textContent = 'Logout';
     loginLink.removeAttribute('href');
     loginLink.addEventListener('click', (e) => {
@@ -355,10 +355,14 @@ document.addEventListener('DOMContentLoaded', () => {
       ['rr_logged_in','rr_username','rr_balance','rr_spent'].forEach(k => localStorage.removeItem(k));
       window.location.href = 'index.html';
     });
-    renderAccount();
+    renderProfile();
   } else {
-    accountNav.style.display = 'none';
+    profileBtn.style.display = 'none';
   }
+  profileBtn.addEventListener('click', () => {
+    renderProfile();
+    $('#profileModal').style.display = 'flex';
+  });
 
   // Mobile nav
   $('#mobileMenu').addEventListener('click', () => {

--- a/login.html
+++ b/login.html
@@ -6,14 +6,20 @@
   <title>Login - Royal Raffles UK</title>
   <link rel="stylesheet" href="css/styles.css"/>
 </head>
-<body>
+<body class="auth-page">
   <main class="main">
     <div class="container">
       <div class="auth-card">
         <h2>Login</h2>
         <form id="loginForm" class="login-form">
-          <input id="username" type="text" placeholder="Username" required />
-          <input id="password" type="password" placeholder="Password" required />
+          <div class="input-group">
+            <span class="input-icon">👤</span>
+            <input id="username" type="text" placeholder="Username" required />
+          </div>
+          <div class="input-group">
+            <span class="input-icon">🔒</span>
+            <input id="password" type="password" placeholder="Password" required />
+          </div>
           <button type="submit" class="button button-gradient">Login</button>
         </form>
       </div>

--- a/login.html
+++ b/login.html
@@ -9,12 +9,14 @@
 <body>
   <main class="main">
     <div class="container">
-      <h2>Login</h2>
-      <form id="loginForm" class="login-form">
-        <input id="username" type="text" placeholder="Username" required />
-        <input id="password" type="password" placeholder="Password" required />
-        <button type="submit" class="button button-gradient">Login</button>
-      </form>
+      <div class="auth-card">
+        <h2>Login</h2>
+        <form id="loginForm" class="login-form">
+          <input id="username" type="text" placeholder="Username" required />
+          <input id="password" type="password" placeholder="Password" required />
+          <button type="submit" class="button button-gradient">Login</button>
+        </form>
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- Replace account link with a profile button and modal showing balance, entries, and stats
- Restyle the login page with a centered card layout
- Deduct balance and refresh profile data when entering raffles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d32758c8332a8edfca92c626a22