### PR TITLE
Add FAQ section and profile enhancements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -218,9 +218,13 @@ body.light-mode {
 .profile-card h4 { font-size:.95rem; margin-bottom:.2rem; }
 .profile-card .tickets { color:var(--text-muted); font-size:.85rem; margin-top:.3rem; }
 
+.top-up { margin:1rem 0; display:flex; gap:.5rem; }
+.top-up input { flex:1; padding:.5rem; border:1px solid rgba(127,23,52,.3); border-radius:8px; background:var(--darker-bg); color:var(--text-light); }
+
 /* Winners & FAQ placeholders */
 .winners-gallery { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1.2rem; }
 .winner-card { background: var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:14px; padding:1.2rem; }
+.winner-card img { width:100%; height:150px; object-fit:cover; border-radius:8px; margin-bottom:.6rem; }
 .faq .faq-item { background: var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:14px; padding:1.2rem; margin-bottom:.9rem; }
 .faq .q { font-weight:800; margin-bottom:.5rem; }
 .faq .a { color:var(--text-muted); }
@@ -230,7 +234,7 @@ body.light-mode {
 .filters select, .filters input { padding:.6rem .8rem; border:1px solid rgba(127,23,52,.3); border-radius:8px; background:var(--darker-bg); color:var(--text-light); }
 
 /* Urgent popup */
-.urgent-popup { position:fixed; bottom:20px; right:20px; width:260px; background:var(--card-bg); border:1px solid rgba(127,23,52,.3); border-radius:12px; padding:1rem; box-shadow:0 8px 20px rgba(0,0,0,.3); display:none; z-index:1500; }
+.urgent-popup { position:fixed; bottom:20px; left:20px; width:260px; background:var(--card-bg); border:1px solid rgba(127,23,52,.3); border-radius:12px; padding:1rem; box-shadow:0 8px 20px rgba(0,0,0,.3); display:none; z-index:1500; }
 .urgent-popup.active { display:block; }
 .urgent-popup h4 { font-family:'Kanit',sans-serif; margin-bottom:.5rem; }
 .urgent-popup ul { list-style:none; max-height:200px; overflow:auto; }
@@ -238,8 +242,12 @@ body.light-mode {
 
 /* Hall of Fame */
 .hall-of-fame { margin-top:2rem; }
-.fame-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap:1rem; }
-.fame-card { background:var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:14px; padding:1rem; text-align:center; }
+.fame-grid { display:flex; justify-content:center; align-items:flex-end; gap:1rem; }
+.fame-card { flex:1; background:var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:12px 12px 0 0; padding:1rem; text-align:center; position:relative; }
+.fame-card::after { content:""; position:absolute; left:0; right:0; bottom:-20px; height:20px; background:var(--card-bg); border:1px solid rgba(127,23,52,.2); border-top:none; border-radius:0 0 12px 12px; }
+.fame-card:nth-child(2)::after { height:40px; bottom:-40px; }
+.fame-card:nth-child(1)::after,
+.fame-card:nth-child(3)::after { height:30px; bottom:-30px; }
 .fame-card h3 { font-family:'Kanit',sans-serif; margin-bottom:.5rem; }
 .fame-card p { color:var(--text-muted); font-size:.9rem; }
 

--- a/index.html
+++ b/index.html
@@ -116,6 +116,12 @@
           </div>
         </section>
 
+        <!-- FAQ -->
+        <section id="faq" class="section faq">
+          <h2>FAQ</h2>
+          <div id="faqItems"></div>
+        </section>
+
       </section>
 
     </div>
@@ -172,7 +178,13 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
+      <p><strong>User:</strong> <span id="modalUsername"></span></p>
+      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
       <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="top-up">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <button id="topUpBtn" class="button button-outline">Top Up</button>
+      </div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>

--- a/js/script.js
+++ b/js/script.js
@@ -51,11 +51,11 @@ const raffles = [
 ];
 
 const winners = [
-  { name: "Sarah Miles", prize: "iPhone 15 Pro", value: 1200, chance: 5, date: "2024-06-15", icon: "🎉" },
-  { name: "James Tully", prize: "BMW M3", value: 70000, chance: 0.5, date: "2024-06-08", icon: "🚗" },
-  { name: "Emma Lane", prize: "Diamond Necklace", value: 5000, chance: 1, date: "2024-06-02", icon: "💎" },
-  { name: "Ryan King", prize: "PS5 + Games", value: 600, chance: 10, date: "2024-05-28", icon: "🎮" },
-  { name: "Sarah Miles", prize: "£100 Gift Card", value: 100, chance: 20, date: "2024-05-15", icon: "💷" }
+  { name: "Sarah Miles", prize: "iPhone 15 Pro", value: 1200, chance: 5, date: "2024-06-15", image: "images/iphone17.png" },
+  { name: "James Tully", prize: "BMW M3", value: 70000, chance: 0.5, date: "2024-06-08", image: "images/bmwm3.png" },
+  { name: "Emma Lane", prize: "Diamond Necklace", value: 5000, chance: 1, date: "2024-06-02", image: "images/rolex.png" },
+  { name: "Ryan King", prize: "PS5 + Games", value: 600, chance: 10, date: "2024-05-28", image: "images/gamingsetup.png" },
+  { name: "Sarah Miles", prize: "£100 Gift Card", value: 100, chance: 20, date: "2024-05-15", image: "images/spaweekend.png" }
 ];
 
 function maskName(name) {
@@ -171,7 +171,7 @@ function renderWinners() {
     const card = document.createElement('div');
     card.className = 'winner-card';
     card.innerHTML = `
-      <div class="winner-image">${w.icon}</div>
+      <img src="${w.image}" alt="${w.prize}" class="winner-image">
       <h3>${maskName(w.name)}</h3>
       <p><strong>Won:</strong> ${w.prize} (£${w.value})</p>
       <small>Chance: ${w.chance}% | ${new Date(w.date).toLocaleDateString()}</small>
@@ -225,7 +225,7 @@ function renderUrgentPopup() {
   const soon = raffles.filter(r => {
     const remaining = r.totalTickets - r.soldTickets;
     const timeLeft = r.endTime - new Date();
-    return remaining / r.totalTickets < 0.1 || timeLeft < 2 * 60 * 60 * 1000;
+    return remaining / r.totalTickets < 0.2 || timeLeft < 12 * 60 * 60 * 1000;
   });
   if (soon.length === 0) return;
   popup.innerHTML = `<h4>Ending Soon</h4><ul>${soon.map(r => `<li>${r.title}</li>`).join('')}</ul>`;
@@ -305,6 +305,8 @@ const demoPast = [
 function renderProfile() {
   const balEl = $('#modalBalance');
   if (!balEl) return;
+  $('#modalUsername').textContent = getUsername();
+  $('#modalEmail').textContent = localStorage.getItem('rr_email') || '—';
   balEl.textContent = getBalance().toFixed(2);
 
   const currentList = $('#modalCurrentEntries');
@@ -458,6 +460,18 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.classList.add('selected');
     });
   });
+
+  const topUpBtn = $('#topUpBtn');
+  if (topUpBtn) {
+    topUpBtn.addEventListener('click', () => {
+      const amt = parseFloat($('#topUpAmount').value);
+      if (!isNaN(amt) && amt > 0) {
+        setBalance(getBalance() + amt);
+        $('#topUpAmount').value = '';
+        renderProfile();
+      }
+    });
+  }
 
   document.body.addEventListener('click', (e) => {
     const enterId = e.target.getAttribute('data-enter');

--- a/lastwinners.html
+++ b/lastwinners.html
@@ -17,6 +17,7 @@
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="raffles.html" class="nav-link">All Raffles</a></li>
         <li><a href="lastwinners.html" class="nav-link">Past Winners</a></li>
+        <li><a href="index.html#faq" class="nav-link">FAQ</a></li>
         <li><button id="profileBtn" class="button button-outline" style="display:none;">Profile</button></li>
         <li><a id="loginLink" class="button button-outline" href="login.html">Login</a></li>
       </ul>
@@ -37,9 +38,9 @@
       <section class="hall-of-fame section" id="hallOfFame">
         <h2>Hall of Fame</h2>
         <div class="fame-grid">
-          <div id="fameBiggest" class="fame-card"></div>
           <div id="fameLuckiest" class="fame-card"></div>
           <div id="fameTop" class="fame-card"></div>
+          <div id="fameBiggest" class="fame-card"></div>
         </div>
       </section>
     </div>
@@ -96,7 +97,13 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
+      <p><strong>User:</strong> <span id="modalUsername"></span></p>
+      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
       <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="top-up">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <button id="topUpBtn" class="button button-outline">Top Up</button>
+      </div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>

--- a/login.html
+++ b/login.html
@@ -17,6 +17,10 @@
             <input id="username" type="text" placeholder="Username" required />
           </div>
           <div class="input-group">
+            <span class="input-icon">✉️</span>
+            <input id="email" type="email" placeholder="Email" required />
+          </div>
+          <div class="input-group">
             <span class="input-icon">🔒</span>
             <input id="password" type="password" placeholder="Password" required />
           </div>
@@ -27,16 +31,18 @@
   </main>
 
   <script>
-    document.getElementById('loginForm').addEventListener('submit', function(e){
-      e.preventDefault();
-      const username = document.getElementById('username').value.trim() || 'user';
-      localStorage.setItem('rr_logged_in', 'true');
-      localStorage.setItem('rr_username', username);
-      if (!localStorage.getItem('rr_balance')) {
-        localStorage.setItem('rr_balance', '100');
-      }
-      if (!localStorage.getItem('rr_spent')) {
-        localStorage.setItem('rr_spent', '0');
+      document.getElementById('loginForm').addEventListener('submit', function(e){
+        e.preventDefault();
+        const username = document.getElementById('username').value.trim() || 'user';
+        const email = document.getElementById('email').value.trim();
+        localStorage.setItem('rr_logged_in', 'true');
+        localStorage.setItem('rr_username', username);
+        localStorage.setItem('rr_email', email);
+        if (!localStorage.getItem('rr_balance')) {
+          localStorage.setItem('rr_balance', '100');
+        }
+        if (!localStorage.getItem('rr_spent')) {
+          localStorage.setItem('rr_spent', '0');
       }
       window.location.href = 'index.html';
     });

--- a/raffles.html
+++ b/raffles.html
@@ -17,6 +17,7 @@
         <li><a href="index.html" class="nav-link">Home</a></li>
         <li><a href="raffles.html" class="nav-link">All Raffles</a></li>
         <li><a href="lastwinners.html" class="nav-link">Past Winners</a></li>
+        <li><a href="index.html#faq" class="nav-link">FAQ</a></li>
         <li><button id="profileBtn" class="button button-outline" style="display:none;">Profile</button></li>
         <li><a id="loginLink" class="button button-outline" href="login.html">Login</a></li>
       </ul>
@@ -106,7 +107,13 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
+      <p><strong>User:</strong> <span id="modalUsername"></span></p>
+      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
       <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="top-up">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <button id="topUpBtn" class="button button-outline">Top Up</button>
+      </div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>


### PR DESCRIPTION
## Summary
- Add bottom-left popup for nearly full or ending raffles
- Show prize images for latest winners and display Hall of Fame on a podium
- Introduce FAQ section and expanded profile modal with user info and balance top-up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3dab92d4833298ad9a7f72e42118