### PR TITLE
Add podium-style hall of fame with prize images

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -244,10 +244,10 @@ body.light-mode {
 .hall-of-fame { margin-top:2rem; }
 .fame-grid { display:flex; justify-content:center; align-items:flex-end; gap:1rem; }
 .fame-card { flex:1; background:var(--card-bg); border:1px solid rgba(127,23,52,.2); border-radius:12px 12px 0 0; padding:1rem; text-align:center; position:relative; }
-.fame-card::after { content:""; position:absolute; left:0; right:0; bottom:-20px; height:20px; background:var(--card-bg); border:1px solid rgba(127,23,52,.2); border-top:none; border-radius:0 0 12px 12px; }
-.fame-card:nth-child(2)::after { height:40px; bottom:-40px; }
-.fame-card:nth-child(1)::after,
-.fame-card:nth-child(3)::after { height:30px; bottom:-30px; }
+.fame-card img { width:100%; height:120px; object-fit:cover; border-radius:8px; margin-bottom:.5rem; }
+.fame-card .pos { position:absolute; top:-25px; left:50%; transform:translateX(-50%); background:var(--claret); color:#fff; width:40px; height:40px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-weight:800; }
+.fame-card:nth-child(2) { transform:translateY(-20px); }
+.fame-card:nth-child(1) { transform:translateY(-10px); }
 .fame-card h3 { font-family:'Kanit',sans-serif; margin-bottom:.5rem; }
 .fame-card p { color:var(--text-muted); font-size:.9rem; }
 

--- a/js/script.js
+++ b/js/script.js
@@ -233,15 +233,34 @@ function renderUrgentPopup() {
 }
 
 function renderHallOfFame() {
-  const bigEl = $('#fameBiggest');
-  if (!bigEl) return;
+  const topEl = $('#fameTop');
+  if (!topEl) return;
   const biggest = winners.reduce((max, w) => w.value > max.value ? w : max, winners[0]);
   const luckiest = winners.reduce((min, w) => w.chance < min.chance ? w : min, winners[0]);
   const counts = winners.reduce((map, w) => { map[w.name] = (map[w.name] || 0) + 1; return map; }, {});
   const topName = Object.keys(counts).reduce((a, b) => counts[a] > counts[b] ? a : b);
-  bigEl.innerHTML = `<h3>Biggest Win</h3><p>${maskName(biggest.name)} won ${biggest.prize} (£${biggest.value})</p>`;
-  $('#fameLuckiest').innerHTML = `<h3>Luckiest Player</h3><p>${maskName(luckiest.name)} won with ${luckiest.chance}% chance</p>`;
-  $('#fameTop').innerHTML = `<h3>Top Winner</h3><p>${maskName(topName)} has ${counts[topName]} win${counts[topName] > 1 ? 's' : ''}</p>`;
+  const topEntry = [...winners].reverse().find(w => w.name === topName);
+
+  $('#fameLuckiest').innerHTML = `
+    <div class="pos">2</div>
+    <img src="${luckiest.image}" alt="${luckiest.prize}" class="fame-image">
+    <h3>Luckiest Player</h3>
+    <p>${maskName(luckiest.name)} won with ${luckiest.chance}% chance</p>
+  `;
+
+  topEl.innerHTML = `
+    <div class="pos">1</div>
+    <img src="${topEntry.image}" alt="${topEntry.prize}" class="fame-image">
+    <h3>Top Winner</h3>
+    <p>${maskName(topName)} has ${counts[topName]} win${counts[topName] > 1 ? 's' : ''}</p>
+  `;
+
+  $('#fameBiggest').innerHTML = `
+    <div class="pos">3</div>
+    <img src="${biggest.image}" alt="${biggest.prize}" class="fame-image">
+    <h3>Biggest Win</h3>
+    <p>${maskName(biggest.name)} won ${biggest.prize} (£${biggest.value})</p>
+  `;
 }
 
 /* ====== ENTRY MODAL + RULES ====== */

--- a/lastwinners.html
+++ b/lastwinners.html
@@ -30,18 +30,18 @@
 
   <main class="main">
     <div class="container">
-      <section class="section">
-        <h1>Latest Winners</h1>
-        <div id="winnersGrid" class="winners-gallery"></div>
-      </section>
-
       <section class="hall-of-fame section" id="hallOfFame">
-        <h2>Hall of Fame</h2>
+        <h1>Hall of Fame</h1>
         <div class="fame-grid">
           <div id="fameLuckiest" class="fame-card"></div>
           <div id="fameTop" class="fame-card"></div>
           <div id="fameBiggest" class="fame-card"></div>
         </div>
+      </section>
+
+      <section class="section">
+        <h2>Latest Winners</h2>
+        <div id="winnersGrid" class="winners-gallery"></div>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- Showcase Hall of Fame at top with podium-style layout and prize images for luckiest, top and biggest winners.
- Display Latest Winners below Hall of Fame.
- Style podium visuals and winner images.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac460b02a08332b2b4573a0b55c554