### PR TITLE
Enhance profile modal layout and top-up handler

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -181,6 +181,7 @@ body.light-mode {
 /* Modal */
 .modal { display:none; position:fixed; inset:0; background: rgba(0,0,0,.8); z-index:2000; justify-content:center; align-items:center; }
 .modal-content { background: var(--card-bg); border:1px solid rgba(127,23,52,.3); border-radius:16px; width:min(520px, 92vw); max-height:90vh; overflow:auto; padding:1.4rem; position:relative; }
+#profileModal .modal-content { width:min(700px,95vw); }
 .modal-content::before { content:""; position:absolute; inset:0 0 auto 0; height:4px; background: linear-gradient(90deg, var(--claret), var(--blue)); }
 .modal-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem; }
 .modal-header h2 { font-family:'Kanit',sans-serif; background: linear-gradient(90deg, var(--claret), var(--blue)); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
@@ -220,6 +221,11 @@ body.light-mode {
 
 .top-up { margin:1rem 0; display:flex; gap:.5rem; }
 .top-up input { flex:1; padding:.5rem; border:1px solid rgba(127,23,52,.3); border-radius:8px; background:var(--darker-bg); color:var(--text-light); }
+.profile-details { display:flex; flex-wrap:wrap; gap:1rem; margin-bottom:1rem; }
+.profile-details > div { flex:1 1 140px; }
+.balance-display { font-size:1.1rem; font-weight:700; }
+.top-up-message { color:var(--blue); font-size:.9rem; margin-top:.4rem; opacity:0; transition:opacity .3s; }
+.top-up-message.show { opacity:1; }
 
 /* Winners & FAQ placeholders */
 .winners-gallery { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1.2rem; }

--- a/index.html
+++ b/index.html
@@ -179,13 +179,16 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
-      <p><strong>User:</strong> <span id="modalUsername"></span></p>
-      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
-      <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="profile-details">
+        <div><strong>User:</strong> <span id="modalUsername"></span></div>
+        <div><strong>Email:</strong> <span id="modalEmail"></span></div>
+        <div class="balance-display"><strong>Balance:</strong> £<span id="modalBalance">0.00</span></div>
+      </div>
       <div class="top-up">
-        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1" step="0.01">
         <button id="topUpBtn" class="button button-outline">Top Up</button>
       </div>
+      <div id="topUpMessage" class="top-up-message"></div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>

--- a/js/script.js
+++ b/js/script.js
@@ -481,6 +481,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const topUpBtn = $('#topUpBtn');
+  const topUpMsg = $('#topUpMessage');
   if (topUpBtn) {
     topUpBtn.addEventListener('click', () => {
       const amt = parseFloat($('#topUpAmount').value);
@@ -488,6 +489,11 @@ document.addEventListener('DOMContentLoaded', () => {
         setBalance(getBalance() + amt);
         $('#topUpAmount').value = '';
         renderProfile();
+        if (topUpMsg) {
+          topUpMsg.textContent = `Added £${amt.toFixed(2)} to balance.`;
+          topUpMsg.classList.add('show');
+          setTimeout(() => topUpMsg.classList.remove('show'), 2000);
+        }
       }
     });
   }

--- a/lastwinners.html
+++ b/lastwinners.html
@@ -98,13 +98,16 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
-      <p><strong>User:</strong> <span id="modalUsername"></span></p>
-      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
-      <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="profile-details">
+        <div><strong>User:</strong> <span id="modalUsername"></span></div>
+        <div><strong>Email:</strong> <span id="modalEmail"></span></div>
+        <div class="balance-display"><strong>Balance:</strong> £<span id="modalBalance">0.00</span></div>
+      </div>
       <div class="top-up">
-        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1" step="0.01">
         <button id="topUpBtn" class="button button-outline">Top Up</button>
       </div>
+      <div id="topUpMessage" class="top-up-message"></div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>

--- a/raffles.html
+++ b/raffles.html
@@ -108,13 +108,16 @@
         <h2>My Profile</h2>
         <button class="close-modal" data-close>×</button>
       </div>
-      <p><strong>User:</strong> <span id="modalUsername"></span></p>
-      <p><strong>Email:</strong> <span id="modalEmail"></span></p>
-      <p>Balance: £<span id="modalBalance">0.00</span></p>
+      <div class="profile-details">
+        <div><strong>User:</strong> <span id="modalUsername"></span></div>
+        <div><strong>Email:</strong> <span id="modalEmail"></span></div>
+        <div class="balance-display"><strong>Balance:</strong> £<span id="modalBalance">0.00</span></div>
+      </div>
       <div class="top-up">
-        <input type="number" id="topUpAmount" placeholder="Add funds" min="1">
+        <input type="number" id="topUpAmount" placeholder="Add funds" min="1" step="0.01">
         <button id="topUpBtn" class="button button-outline">Top Up</button>
       </div>
+      <div id="topUpMessage" class="top-up-message"></div>
       <h3>Current Entries</h3>
       <div id="modalCurrentEntries" class="profile-grid"></div>
       <h3>Past Raffles</h3>


### PR DESCRIPTION
## Summary
- widen profile modal and introduce responsive user/balance sections
- add confirmation message and decimal support to top-up flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a2eba908332a0c940453cb71d73